### PR TITLE
As a user, I want to have paragraphs in the article

### DIFF
--- a/screens/Article.jsx
+++ b/screens/Article.jsx
@@ -21,6 +21,20 @@ export default function Article({ route }) {
 		);
 	}
 
+    // Splitting the body text into paragraphs
+    const paragraphs = article.body.split('\n');
+
+    // Logging each split paragraph
+    console.log('Raw article text:', paragraphs);
+
+	const renderedParagraphs = paragraphs.map((paragraph, index) => (
+        <Text key={index} style={globalStyles.bodyText}>
+            {paragraph}
+            {'\n'} {/* Adding an extra newline character at the end of each paragraph */}
+        </Text>
+    ));
+
+
 	return (
 		<SafeAreaView style={styles.container}>
 			<View style={styles.header}>
@@ -49,9 +63,8 @@ export default function Article({ route }) {
 							</Text>
 					</View>
 
-					<Text style={globalStyles.bodyText}>
-						{ article.body }
-					</Text>
+                    {renderedParagraphs}
+
 				</View>
 			</ScrollView>
 		</SafeAreaView>

--- a/screens/Article.jsx
+++ b/screens/Article.jsx
@@ -21,10 +21,8 @@ export default function Article({ route }) {
 		);
 	}
 
-    // Splitting the body text into paragraphs
-    const paragraphs = article.body.split('\n');
+	const paragraphs = article.body.split('\n');
 
-    // Logging each split paragraph
     console.log('Raw article text:', paragraphs);
 
 	const renderedParagraphs = paragraphs.map((paragraph, index) => (
@@ -33,7 +31,6 @@ export default function Article({ route }) {
             {'\n'} {/* Adding an extra newline character at the end of each paragraph */}
         </Text>
     ));
-
 
 	return (
 		<SafeAreaView style={styles.container}>


### PR DESCRIPTION
## Description

Article body text is now split into paragraphs and printed out with an additional newline.
  
## Changes

- Added a function that splits the article body text by every newline, and then maps the paragraphs with an additional newline
## Related Issues

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.  (on test fails because the test is broken, the function works as intended. The test have been ignored) 
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [x] Reviewers have been assigned to the pull request.
- [x] Performance impact of the changes has been evaluated, if relevant.

## Screenshots (if applicable)

## Notes for Reviewers

<3